### PR TITLE
Remove unnecessary Null Checks And Assignments

### DIFF
--- a/WatsonTcp/WatsonTcpClient.cs
+++ b/WatsonTcp/WatsonTcpClient.cs
@@ -63,16 +63,15 @@ namespace WatsonTcp
             if (serverPort < 1) throw new ArgumentOutOfRangeException(nameof(serverPort));
             if (messageReceived == null) throw new ArgumentNullException(nameof(messageReceived));
 
-            if (serverConnected != null) _ServerConnected = serverConnected;
-            else _ServerConnected = null;
-
-            if (serverDisconnected != null) _ServerDisconnected = serverDisconnected;
-            else _ServerDisconnected = null;
-
             _ServerIp = serverIp;
             _ServerPort = serverPort;
-            _Debug = debug;
+
+            _ServerConnected = serverConnected;
+            _ServerDisconnected = serverDisconnected;
             _MessageReceived = messageReceived;
+
+            _Debug = debug;
+
             _SendLock = new SemaphoreSlim(1);
 
             _Client = new TcpClient();

--- a/WatsonTcp/WatsonTcpServer.cs
+++ b/WatsonTcp/WatsonTcpServer.cs
@@ -61,13 +61,10 @@ namespace WatsonTcp
             if (listenerPort < 1) throw new ArgumentOutOfRangeException(nameof(listenerPort));
             if (messageReceived == null) throw new ArgumentNullException(nameof(_MessageReceived));
 
-            if (clientConnected == null) _ClientConnected = null;
-            else _ClientConnected = clientConnected;
-
-            if (clientDisconnected == null) _ClientDisconnected = null;
-            else _ClientDisconnected = clientDisconnected;
-
+            _ClientConnected = clientConnected;
+            _ClientDisconnected = clientDisconnected;
             _MessageReceived = messageReceived;
+
             _Debug = debug;
 
             _PermittedIps = null;
@@ -117,13 +114,10 @@ namespace WatsonTcp
             if (listenerPort < 1) throw new ArgumentOutOfRangeException(nameof(listenerPort));
             if (messageReceived == null) throw new ArgumentNullException(nameof(_MessageReceived));
 
-            if (clientConnected == null) _ClientConnected = null;
-            else _ClientConnected = clientConnected;
-
-            if (clientDisconnected == null) _ClientDisconnected = null;
-            else _ClientDisconnected = clientDisconnected;
-
+            _ClientConnected = clientConnected;
+            _ClientDisconnected = clientDisconnected;
             _MessageReceived = messageReceived;
+
             _Debug = debug;
 
             if (permittedIps != null && permittedIps.Count() > 0) _PermittedIps = new List<string>(permittedIps);

--- a/WatsonTcp/WatsonTcpSslClient.cs
+++ b/WatsonTcp/WatsonTcpSslClient.cs
@@ -78,17 +78,16 @@ namespace WatsonTcp
             if (serverPort < 1) throw new ArgumentOutOfRangeException(nameof(serverPort));
             if (messageReceived == null) throw new ArgumentNullException(nameof(messageReceived));
 
-            if (serverConnected != null) _ServerConnected = serverConnected;
-            else _ServerConnected = null;
-
-            if (serverDisconnected != null) _ServerDisconnected = serverDisconnected;
-            else _ServerDisconnected = null;
-
             _ServerIp = serverIp;
             _ServerPort = serverPort;
-            _Debug = debug;
             _AcceptInvalidCerts = acceptInvalidCerts;
+
+            _ServerConnected = serverConnected;
+            _ServerDisconnected = serverDisconnected;
             _MessageReceived = messageReceived;
+
+            _Debug = debug;
+
             _SendLock = new SemaphoreSlim(1);
 
             _SslCertificate = null;

--- a/WatsonTcp/WatsonTcpSslServer.cs
+++ b/WatsonTcp/WatsonTcpSslServer.cs
@@ -75,17 +75,15 @@ namespace WatsonTcp
             if (listenerPort < 1) throw new ArgumentOutOfRangeException(nameof(listenerPort));
             if (messageReceived == null) throw new ArgumentNullException(nameof(_MessageReceived));
             if (String.IsNullOrEmpty(pfxCertFile)) throw new ArgumentNullException(nameof(pfxCertFile));
-            
-            if (clientConnected == null) _ClientConnected = null;
-            else _ClientConnected = clientConnected;
 
-            if (clientDisconnected == null) _ClientDisconnected = null;
-            else _ClientDisconnected = clientDisconnected;
-
-            _MessageReceived = messageReceived;
-            _Debug = debug;
             _AcceptInvalidCerts = acceptInvalidCerts;
             _MutuallyAuthenticate = mutualAuthentication;
+
+            _ClientConnected = clientConnected;
+            _ClientDisconnected = clientDisconnected;
+            _MessageReceived = messageReceived;
+
+            _Debug = debug;
 
             _PermittedIps = null;
 
@@ -146,16 +144,14 @@ namespace WatsonTcp
             if (listenerPort < 1) throw new ArgumentOutOfRangeException(nameof(listenerPort));
             if (messageReceived == null) throw new ArgumentNullException(nameof(_MessageReceived));
 
-            if (clientConnected == null) _ClientConnected = null;
-            else _ClientConnected = clientConnected;
-
-            if (clientDisconnected == null) _ClientDisconnected = null;
-            else _ClientDisconnected = clientDisconnected;
-
-            _MessageReceived = messageReceived;
-            _Debug = debug;
             _AcceptInvalidCerts = acceptInvalidCerts;
             _MutuallyAuthenticate = mutualAuthentication;
+
+            _ClientConnected = clientConnected;
+            _ClientDisconnected = clientDisconnected;
+            _MessageReceived = messageReceived;
+
+            _Debug = debug;
 
             if (permittedIps != null && permittedIps.Count() > 0) _PermittedIps = new List<string>(permittedIps);
 


### PR DESCRIPTION
This null checks and assignments are unnecessary.

Since you will either pass null or Func.
So setting it to null if what is passed is null can be tidied up.