### PR TITLE
Simplify ip port usage

### DIFF
--- a/WatsonTcp/ClientMetadata.cs
+++ b/WatsonTcp/ClientMetadata.cs
@@ -13,31 +13,25 @@ namespace WatsonTcp
     {
         #region Public-Members
 
-        public string Ip;
-        public int Port;
         public TcpClient Tcp;
         public SslStream Ssl;
 
         #endregion
 
         #region Private-Members
-        
+
+        private string ipPort;
+
         #endregion
 
         #region Constructors-and-Factories
-
-        public ClientMetadata()
-        {
-
-        }
 
         public ClientMetadata(TcpClient tcp)
         {
             if (tcp == null) throw new ArgumentNullException(nameof(tcp));
             Tcp = tcp;
 
-            Ip = ((IPEndPoint)Tcp.Client.RemoteEndPoint).Address.ToString();
-            Port = ((IPEndPoint)Tcp.Client.RemoteEndPoint).Port;
+            ipPort = tcp.Client.RemoteEndPoint.ToString();
         }
 
         public ClientMetadata(TcpClient tcp, SslStream ssl)
@@ -48,17 +42,16 @@ namespace WatsonTcp
             Tcp = tcp;
             Ssl = ssl;
 
-            Ip = ((IPEndPoint)Tcp.Client.RemoteEndPoint).Address.ToString();
-            Port = ((IPEndPoint)Tcp.Client.RemoteEndPoint).Port;
+            ipPort = tcp.Client.RemoteEndPoint.ToString();
         }
 
         #endregion
 
         #region Public-Methods
 
-        public string IpPort()
+        public string IpPort
         {
-            return Ip + ":" + Port;
+            get { return ipPort; }
         }
 
         #endregion

--- a/WatsonTcp/WatsonTcpServer.cs
+++ b/WatsonTcp/WatsonTcpServer.cs
@@ -74,7 +74,7 @@ namespace WatsonTcp
 
             if (String.IsNullOrEmpty(listenerIp))
             {
-                _ListenerIpAddress = System.Net.IPAddress.Any;
+                _ListenerIpAddress = IPAddress.Any;
                 _ListenerIp = _ListenerIpAddress.ToString();
             }
             else
@@ -130,7 +130,7 @@ namespace WatsonTcp
 
             if (String.IsNullOrEmpty(listenerIp))
             {
-                _ListenerIpAddress = System.Net.IPAddress.Any;
+                _ListenerIpAddress = IPAddress.Any;
                 _ListenerIp = _ListenerIpAddress.ToString();
             }
             else
@@ -279,7 +279,6 @@ namespace WatsonTcp
                 #region Get-Tuple-and-Check-IP
 
                 string clientIp = ((IPEndPoint)client.Client.RemoteEndPoint).Address.ToString();
-                int clientPort = ((IPEndPoint)client.Client.RemoteEndPoint).Port;
 
                 if (_PermittedIps != null && _PermittedIps.Count > 0)
                 {
@@ -291,7 +290,7 @@ namespace WatsonTcp
                     }
                 }
 
-                Log("AcceptConnections accepted connection from " + clientIp + ":" + clientPort);
+                Log("AcceptConnections accepted connection from " + client.Client.RemoteEndPoint.ToString());
 
                 #endregion
 
@@ -305,7 +304,7 @@ namespace WatsonTcp
                     ClientMetadata currClient = new ClientMetadata(client);
                     if (!AddClient(currClient))
                     {
-                        Log("*** AcceptConnections unable to add client " + currClient.IpPort());
+                        Log("*** AcceptConnections unable to add client " + currClient.IpPort);
                         client.Close();
                         return;
                     }
@@ -316,10 +315,10 @@ namespace WatsonTcp
 
                     CancellationToken dataReceiverToken = default(CancellationToken);
 
-                    Log("AcceptConnections starting data receiver for " + currClient.IpPort() + " (now " + _ActiveClients + " clients)");
+                    Log("AcceptConnections starting data receiver for " + currClient.IpPort + " (now " + _ActiveClients + " clients)");
                     if (_ClientConnected != null)
                     {
-                        Task.Run(() => _ClientConnected(currClient.IpPort()));
+                        Task.Run(() => _ClientConnected(currClient.IpPort));
                     }
 
                     Task.Run(async () => await DataReceiver(currClient, dataReceiverToken), dataReceiverToken);
@@ -381,7 +380,7 @@ namespace WatsonTcp
 
                         if (_MessageReceived != null)
                         {
-                            var unawaited = Task.Run(() => _MessageReceived(client.IpPort(), data));
+                            var unawaited = Task.Run(() => _MessageReceived(client.IpPort, data));
                         }
                     }
                     catch (Exception)
@@ -398,36 +397,36 @@ namespace WatsonTcp
                 RemoveClient(client);
                 if (_ClientDisconnected != null)
                 {
-                    var unawaited = Task.Run(() => _ClientDisconnected(client.IpPort()));
+                    var unawaited = Task.Run(() => _ClientDisconnected(client.IpPort));
                 }
-                Log("DataReceiver client " + client.IpPort() + " disconnected (now " + _ActiveClients + " clients active)");
+                Log("DataReceiver client " + client.IpPort + " disconnected (now " + _ActiveClients + " clients active)");
             }
         }
 
         private bool AddClient(ClientMetadata client)
         { 
             ClientMetadata removedClient;
-            if (!_Clients.TryRemove(client.IpPort(), out removedClient))
+            if (!_Clients.TryRemove(client.IpPort, out removedClient))
             {
                 // do nothing, it probably did not exist anyway
             }
 
-            _Clients.TryAdd(client.IpPort(), client);
-            Log("AddClient added client " + client.IpPort());
+            _Clients.TryAdd(client.IpPort, client);
+            Log("AddClient added client " + client.IpPort);
             return true;
         }
 
         private bool RemoveClient(ClientMetadata client)
         { 
             ClientMetadata removedClient;
-            if (!_Clients.TryRemove(client.IpPort(), out removedClient))
+            if (!_Clients.TryRemove(client.IpPort, out removedClient))
             {
-                Log("RemoveClient unable to remove client " + client.IpPort());
+                Log("RemoveClient unable to remove client " + client.IpPort);
                 return false;
             }
             else
             {
-                Log("RemoveClient removed client " + client.IpPort());
+                Log("RemoveClient removed client " + client.IpPort);
                 return true;
             }
         }
@@ -521,7 +520,7 @@ namespace WatsonTcp
 
                 if (!Int64.TryParse(header, out contentLength))
                 {
-                    Log("*** MessageRead malformed message from " + client.IpPort() + " (message header not an integer)");
+                    Log("*** MessageRead malformed message from " + client.IpPort + " (message header not an integer)");
                     return null;
                 }
 
@@ -597,13 +596,13 @@ namespace WatsonTcp
 
             if (contentBytes == null || contentBytes.Length < 1)
             {
-                Log("*** MessageRead " + client.IpPort() + " no content read");
+                Log("*** MessageRead " + client.IpPort + " no content read");
                 return null;
             }
 
             if (contentBytes.Length != contentLength)
             {
-                Log("*** MessageRead " + client.IpPort() + " content length " + contentBytes.Length + " bytes does not match header value " + contentLength + ", discarding");
+                Log("*** MessageRead " + client.IpPort + " content length " + contentBytes.Length + " bytes does not match header value " + contentLength + ", discarding");
                 return null;
             }
 
@@ -698,7 +697,7 @@ namespace WatsonTcp
 
                 if (!Int64.TryParse(header, out contentLength))
                 {
-                    Log("*** MessageReadAsync malformed message from " + client.IpPort() + " (message header not an integer)");
+                    Log("*** MessageReadAsync malformed message from " + client.IpPort + " (message header not an integer)");
                     return null;
                 }
                     
@@ -775,13 +774,13 @@ namespace WatsonTcp
 
             if (contentBytes == null || contentBytes.Length < 1)
             {
-                Log("*** MessageReadAsync " + client.IpPort() + " no content read");
+                Log("*** MessageReadAsync " + client.IpPort + " no content read");
                 return null;
             }
 
             if (contentBytes.Length != contentLength)
             {
-                Log("*** MessageReadAsync " + client.IpPort() + " content length " + contentBytes.Length + " bytes does not match header value " + contentLength + ", discarding");
+                Log("*** MessageReadAsync " + client.IpPort + " content length " + contentBytes.Length + " bytes does not match header value " + contentLength + ", discarding");
                 return null;
             }
 
@@ -824,7 +823,7 @@ namespace WatsonTcp
             }
             catch (Exception)
             {
-                Log("*** MessageWrite " + client.IpPort() + " disconnected due to exception");
+                Log("*** MessageWrite " + client.IpPort + " disconnected due to exception");
                 return false;
             }
         }
@@ -864,7 +863,7 @@ namespace WatsonTcp
             }
             catch (Exception)
             {
-                Log("*** MessageWriteAsync " + client.IpPort() + " disconnected due to exception");
+                Log("*** MessageWriteAsync " + client.IpPort + " disconnected due to exception");
                 return false;
             }
         }

--- a/WatsonTcp/WatsonTcpServer.cs
+++ b/WatsonTcp/WatsonTcpServer.cs
@@ -271,26 +271,26 @@ namespace WatsonTcp
                 #region Accept-Connection
 
                 _Token.ThrowIfCancellationRequested();
-                TcpClient client = await _Listener.AcceptTcpClientAsync();
-                client.LingerState.Enabled = false;
+                TcpClient tcpClient = await _Listener.AcceptTcpClientAsync();
+                tcpClient.LingerState.Enabled = false;
 
                 #endregion
 
                 #region Get-Tuple-and-Check-IP
 
-                string clientIp = ((IPEndPoint)client.Client.RemoteEndPoint).Address.ToString();
+                string clientIp = ((IPEndPoint)tcpClient.Client.RemoteEndPoint).Address.ToString();
 
                 if (_PermittedIps != null && _PermittedIps.Count > 0)
                 {
                     if (!_PermittedIps.Contains(clientIp))
                     {
                         Log("*** AcceptConnections rejecting connection from " + clientIp + " (not permitted)");
-                        client.Close();
+                        tcpClient.Close();
                         return;
                     }
                 }
 
-                Log("AcceptConnections accepted connection from " + client.Client.RemoteEndPoint.ToString());
+                Log("AcceptConnections accepted connection from " + tcpClient.Client.RemoteEndPoint.ToString());
 
                 #endregion
 
@@ -301,11 +301,11 @@ namespace WatsonTcp
                     _ActiveClients++;
                     // Do not decrement in this block, decrement is done by the connection reader
 
-                    ClientMetadata currClient = new ClientMetadata(client);
+                    ClientMetadata currClient = new ClientMetadata(tcpClient);
                     if (!AddClient(currClient))
                     {
                         Log("*** AcceptConnections unable to add client " + currClient.IpPort);
-                        client.Close();
+                        tcpClient.Close();
                         return;
                     }
 


### PR DESCRIPTION
Changed ClientMetadata's IpPort() method to a accessor of 
private string ipPort

Assign this by using 
tcp.Client.RemoteEndPoint.ToString()

instead of doing the ip and port separately then joining them together.

Also made naming of the TcpClient local variable consistent between WatsonTcpServer and WatsonTcpSslServer