### PR TITLE
Since SyncResponse uses SyncRequest expiration don't correct

### DIFF
--- a/WatsonTcp/WatsonMessage.cs
+++ b/WatsonTcp/WatsonMessage.cs
@@ -220,7 +220,7 @@ namespace WatsonTcp
             Expiration = expiration;
             ConversationGuid = convGuid;
             Compression = compression;
-            if (SyncRequest || SyncResponse) SenderTimestamp = DateTime.Now;
+            if (SyncRequest) SenderTimestamp = DateTime.Now;
 
             _DataStream = stream;
             _Logger = logger; 


### PR DESCRIPTION
I still discovered some time-outs and did some additional testing and found out what was wrong:
SyncResponse uses the original expiration from SyncRequest, so no additional correction is needed.