### PR TITLE
Fixed Exceptions in Datareceiver when Dispose is too fast

### DIFF
--- a/WatsonTcp/ClientMetadata.cs
+++ b/WatsonTcp/ClientMetadata.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace WatsonTcp
 {
@@ -64,6 +65,8 @@ namespace WatsonTcp
             }
         }
 
+        internal Task DataReceiver { get; set; } = null;
+
         internal SemaphoreSlim WriteLock = new SemaphoreSlim(1, 1);
         internal SemaphoreSlim ReadLock = new SemaphoreSlim(1, 1);
 
@@ -115,6 +118,11 @@ namespace WatsonTcp
             {
                 _TcpClient.Close();
                 _TcpClient.Dispose();
+            }
+
+            while(DataReceiver?.Status== TaskStatus.Running)
+            {
+                Task.Delay(1).Wait();
             }
         } 
     }

--- a/WatsonTcp/WatsonTcpClient.cs
+++ b/WatsonTcp/WatsonTcpClient.cs
@@ -426,6 +426,11 @@ namespace WatsonTcp
                 _Client.Close();
             }
 
+            while (_DataReceiver?.Status == TaskStatus.Running)
+            {
+                Task.Delay(1).Wait();
+            }
+
             Connected = false;
 
             _Settings.Logger?.Invoke(Severity.Info, _Header + "disconnected from " + _ServerIp + ":" + _ServerPort);
@@ -684,7 +689,7 @@ namespace WatsonTcp
 
                     if (_Client == null || !_Client.Connected)
                     {
-                        _Settings.Logger?.Invoke(Severity.Debug, _Header + "disconnect detected");
+                        _Settings?.Logger?.Invoke(Severity.Debug, _Header + "disconnect detected");
                         break;
                     }
 
@@ -697,7 +702,7 @@ namespace WatsonTcp
                     bool buildSuccess = await msg.BuildFromStream(_Token).ConfigureAwait(false);
                     if (!buildSuccess)
                     {
-                        _Settings.Logger?.Invoke(Severity.Debug, _Header + "disconnect detected");
+                        _Settings?.Logger?.Invoke(Severity.Debug, _Header + "disconnect detected");
                         break;
                     }
 
@@ -713,19 +718,19 @@ namespace WatsonTcp
 
                     if (msg.Status == MessageStatus.Removed)
                     {
-                        _Settings.Logger?.Invoke(Severity.Info, _Header + "disconnect due to server-side removal");
+                        _Settings?.Logger?.Invoke(Severity.Info, _Header + "disconnect due to server-side removal");
                         reason = DisconnectReason.Removed;
                         break;
                     }
                     else if (msg.Status == MessageStatus.Shutdown)
                     {
-                        _Settings.Logger?.Invoke(Severity.Info, _Header + "disconnect due to server shutdown");
+                        _Settings?.Logger?.Invoke(Severity.Info, _Header + "disconnect due to server shutdown");
                         reason = DisconnectReason.Shutdown;
                         break;
                     }
                     else if (msg.Status == MessageStatus.Timeout)
                     {
-                        _Settings.Logger?.Invoke(Severity.Info, _Header + "disconnect due to timeout");
+                        _Settings?.Logger?.Invoke(Severity.Info, _Header + "disconnect due to timeout");
                         reason = DisconnectReason.Timeout;
                         break;
                     }

--- a/WatsonTcp/WatsonTcpClientEvents.cs
+++ b/WatsonTcp/WatsonTcpClientEvents.cs
@@ -139,14 +139,13 @@ namespace WatsonTcp
         {
             if (action == null) return;
 
-            Action<Severity, string> logger = ((WatsonTcpClient)sender).Settings.Logger;
-
             try
             {
                 action.Invoke();
             }
             catch (Exception e)
             {
+                Action<Severity, string> logger = ((WatsonTcpClient)sender).Settings?.Logger;
                 logger?.Invoke(Severity.Error, "Event handler exception in " + handler + ": " + Environment.NewLine + SerializationHelper.SerializeJson(e, true));
             }
         }

--- a/WatsonTcp/WatsonTcpServer.cs
+++ b/WatsonTcp/WatsonTcpServer.cs
@@ -920,8 +920,7 @@ namespace WatsonTcp
             #region Start-Data-Receiver
 
             _Settings.Logger?.Invoke(Severity.Debug, _Header + "starting data receiver for " + client.IpPort);
-            Task unawaited = Task.Run(() => DataReceiver(client, token), token);
-
+            client.DataReceiver = Task.Run(() => DataReceiver(client, token), token);
             _Events.HandleClientConnected(this, new ConnectionEventArgs(client.IpPort));
 
             #endregion 
@@ -1017,7 +1016,7 @@ namespace WatsonTcp
                     bool buildSuccess = await msg.BuildFromStream(token).ConfigureAwait(false);
                     if (!buildSuccess)
                     {
-                        _Settings.Logger?.Invoke(Severity.Debug, _Header + "disconnect detected for client " + client.IpPort);
+                        _Settings?.Logger?.Invoke(Severity.Debug, _Header + "disconnect detected for client " + client.IpPort);
                         break;
                     }
 


### PR DESCRIPTION
Fixed Exceptions in Datareceiver when Dispose() method is called before disconnection is completely done.