### PR TITLE
Implemented property for setting up TLS version (.Net 5.0 or greater)

### DIFF
--- a/WatsonTcp/TlsExtensions.cs
+++ b/WatsonTcp/TlsExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Security.Authentication;
+
+namespace WatsonTcp
+{
+    static class TlsExtensions
+    {
+        public static SslProtocols ToSslProtocols(this TlsVersion tlsVersion)
+        {
+            switch (tlsVersion)
+            {
+                case TlsVersion.Tls12:
+                    return SslProtocols.Tls12;
+#if NET5_0_OR_GREATER
+                case TlsVersion.Tls13:
+                    return SslProtocols.Tls13;
+#endif
+                default: 
+                    throw new ArgumentOutOfRangeException($"Unsupported TLS version {tlsVersion}");
+            }
+        }
+    }
+}

--- a/WatsonTcp/TlsVersion.cs
+++ b/WatsonTcp/TlsVersion.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace WatsonTcp
+{
+    /// <summary>
+    /// Supported TLS versions
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum TlsVersion
+    {
+        /// <summary>
+        /// Use TLS 1.2 (you can't go below this)
+        /// </summary>
+        Tls12,
+        /// <summary>
+        /// Use TLS 1.3 (only valid for .Net 5.0 or greater)
+        /// </summary>
+        Tls13,
+    }
+}

--- a/WatsonTcp/WatsonTcp.xml
+++ b/WatsonTcp/WatsonTcp.xml
@@ -345,6 +345,21 @@
             <param name="metadata">Metadata to attach to the response.</param>
             <param name="data">Data to send as a response.</param>
         </member>
+        <member name="T:WatsonTcp.TlsVersion">
+            <summary>
+            Supported TLS versions
+            </summary>
+        </member>
+        <member name="F:WatsonTcp.TlsVersion.Tls12">
+            <summary>
+            Use TLS 1.2 (you can't go below this)
+            </summary>
+        </member>
+        <member name="F:WatsonTcp.TlsVersion.Tls13">
+            <summary>
+            Use TLS 1.3 (only valid for .Net 5.0 or greater)
+            </summary>
+        </member>
         <member name="P:WatsonTcp.WatsonMessage.ContentLength">
             <summary>
             Length of the data.
@@ -556,7 +571,7 @@
             <param name="serverIp">The IP address or hostname of the server.</param>
             <param name="serverPort">The TCP port on which the server is listening.</param>
         </member>
-        <member name="M:WatsonTcp.WatsonTcpClient.#ctor(System.String,System.Int32,System.String,System.String)">
+        <member name="M:WatsonTcp.WatsonTcpClient.#ctor(System.String,System.Int32,System.String,System.String,WatsonTcp.TlsVersion)">
             <summary>
             Initialize the Watson TCP client with SSL.  Call Start() afterward to connect to the server.
             </summary>
@@ -564,14 +579,16 @@
             <param name="serverPort">The TCP port on which the server is listening.</param>
             <param name="pfxCertFile">The file containing the SSL certificate.</param>
             <param name="pfxCertPass">The password for the SSL certificate.</param>
+            <param name="tlsVersion">The TLS version used for this connection</param>
         </member>
-        <member name="M:WatsonTcp.WatsonTcpClient.#ctor(System.String,System.Int32,System.Security.Cryptography.X509Certificates.X509Certificate2)">
+        <member name="M:WatsonTcp.WatsonTcpClient.#ctor(System.String,System.Int32,System.Security.Cryptography.X509Certificates.X509Certificate2,WatsonTcp.TlsVersion)">
             <summary>
             Initialize the Watson TCP client with SSL.  Call Start() afterward to connect to the server.
             </summary>
             <param name="serverIp">The IP address or hostname of the server.</param>
             <param name="serverPort">The TCP port on which the server is listening.</param>
             <param name="cert">The SSL certificate</param>
+            <param name="tlsVersion">The TLS version used for this conenction</param>
         </member>
         <member name="M:WatsonTcp.WatsonTcpClient.Dispose">
             <summary>        
@@ -904,7 +921,7 @@
             <param name="listenerIp">The IP address on which the server should listen.  If null, listen on any IP address (may require administrative privileges).</param>
             <param name="listenerPort">The TCP port on which the server should listen.</param>
         </member>
-        <member name="M:WatsonTcp.WatsonTcpServer.#ctor(System.String,System.Int32,System.String,System.String)">
+        <member name="M:WatsonTcp.WatsonTcpServer.#ctor(System.String,System.Int32,System.String,System.String,WatsonTcp.TlsVersion)">
             <summary>
             Initialize the Watson TCP server with SSL.  
             Supply a specific IP address on which to listen.  Otherwise, use 'null' for the IP address to listen on any IP address.
@@ -915,8 +932,9 @@
             <param name="listenerPort">The TCP port on which the server should listen.</param>
             <param name="pfxCertFile">The file containing the SSL certificate.</param>
             <param name="pfxCertPass">The password for the SSL certificate.</param>
+            <param name="tlsVersion">The TLS version used for this connection</param>
         </member>
-        <member name="M:WatsonTcp.WatsonTcpServer.#ctor(System.String,System.Int32,System.Security.Cryptography.X509Certificates.X509Certificate2)">
+        <member name="M:WatsonTcp.WatsonTcpServer.#ctor(System.String,System.Int32,System.Security.Cryptography.X509Certificates.X509Certificate2,WatsonTcp.TlsVersion)">
             <summary>
             Initialize the Watson TCP server with SSL.  
             Supply a specific IP address on which to listen.  Otherwise, use 'null' for the IP address to listen on any IP address.
@@ -926,6 +944,7 @@
             <param name="listenerIp">The IP address on which the server should listen.  If null, listen on any IP address (may require administrative privileges).</param>
             <param name="listenerPort">The TCP port on which the server should listen.</param>
             <param name="cert">The SSL certificate.</param>
+            <param name="tlsVersion">The TLS version used for this connection</param>
             <exception cref="T:System.ArgumentOutOfRangeException"></exception>
         </member>
         <member name="M:WatsonTcp.WatsonTcpServer.Dispose">

--- a/WatsonTcp/WatsonTcpClient.cs
+++ b/WatsonTcp/WatsonTcpClient.cs
@@ -115,6 +115,7 @@ namespace WatsonTcp
         private WatsonTcpKeepaliveSettings _Keepalive = new WatsonTcpKeepaliveSettings();
 
         private Mode _Mode = Mode.Tcp;
+        private TlsVersion _TlsVersion; 
         private string _SourceIp = null;
         private int _SourcePort = 0;
         private string _ServerIp = null;
@@ -167,16 +168,19 @@ namespace WatsonTcp
         /// <param name="serverPort">The TCP port on which the server is listening.</param>
         /// <param name="pfxCertFile">The file containing the SSL certificate.</param>
         /// <param name="pfxCertPass">The password for the SSL certificate.</param>
+        /// <param name="tlsVersion">The TLS version used for this connection</param>
         public WatsonTcpClient(
             string serverIp,
             int serverPort,
             string pfxCertFile,
-            string pfxCertPass)
+            string pfxCertPass,
+            TlsVersion tlsVersion = TlsVersion.Tls12)
         {
             if (String.IsNullOrEmpty(serverIp)) throw new ArgumentNullException(nameof(serverIp));
             if (serverPort < 0) throw new ArgumentOutOfRangeException(nameof(serverPort));
               
             _Mode = Mode.Ssl;
+            _TlsVersion = tlsVersion;
             _ServerIp = serverIp;
             _ServerPort = serverPort;
 
@@ -208,16 +212,19 @@ namespace WatsonTcp
         /// <param name="serverIp">The IP address or hostname of the server.</param>
         /// <param name="serverPort">The TCP port on which the server is listening.</param>
         /// <param name="cert">The SSL certificate</param>
+        /// <param name="tlsVersion">The TLS version used for this conenction</param>
         public WatsonTcpClient(
             string serverIp, 
             int serverPort, 
-            X509Certificate2 cert)
+            X509Certificate2 cert,
+            TlsVersion tlsVersion = TlsVersion.Tls12)
         {
             if (String.IsNullOrEmpty(serverIp)) throw new ArgumentNullException(nameof(serverIp));
             if (serverPort < 0) throw new ArgumentOutOfRangeException(nameof(serverPort));
             if (cert == null) throw new ArgumentNullException(nameof(cert));
              
             _Mode = Mode.Ssl;
+            _TlsVersion = tlsVersion;
             _SslCertificate = cert;
             _ServerIp = serverIp;
             _ServerPort = serverPort;
@@ -343,7 +350,7 @@ namespace WatsonTcp
                     else
                         _SslStream = new SslStream(_Client.GetStream(), false);
 
-                    _SslStream.AuthenticateAsClient(_ServerIp, _SslCertificateCollection, SslProtocols.Tls12, !_Settings.AcceptInvalidCertificates);
+                    _SslStream.AuthenticateAsClient(_ServerIp, _SslCertificateCollection, _TlsVersion.ToSslProtocols(), !_Settings.AcceptInvalidCertificates);
 
                     if (!_SslStream.IsEncrypted)
                     {


### PR DESCRIPTION
Since in that list of supported frameworks, only .Net 5.0 is capable of TLS 1.3, only that corresponding output will support TLS 1.3.
I guess it would make sense to add .Net 4.7 or 4.8 as an output framework. 
When merged, I would also update WatsonMesh to support TLS 1.3