### PR TITLE
Adding additional configuration options when accepting invalid certificates

### DIFF
--- a/WatsonTcp/WatsonTcp.xml
+++ b/WatsonTcp/WatsonTcp.xml
@@ -867,12 +867,6 @@
             Stores the parameters for the <see cref="T:System.Net.Security.SslStream"/> used by clients.
             </summary>
         </member>
-        <member name="P:WatsonTcp.WatsonTcpClientSslConfiguration.CheckCertificateRevocation">
-            <summary>
-            Gets or sets a <see cref="T:System.Boolean"/> value that specifies whether the certificate revocation list
-            is checked during authentication.
-            </summary>
-        </member>
         <member name="P:WatsonTcp.WatsonTcpClientSslConfiguration.ClientCertificateSelectionCallback">
             <summary>
             Gets or sets a <see cref="T:System.Net.Security.LocalCertificateSelectionCallback"/> delegate responsible for
@@ -1316,12 +1310,6 @@
         <member name="T:WatsonTcp.WatsonTcpServerSslConfiguration">
             <summary>
             Stores the parameters for the <see cref="T:System.Net.Security.SslStream"/> used by servers.
-            </summary>
-        </member>
-        <member name="P:WatsonTcp.WatsonTcpServerSslConfiguration.CheckCertificateRevocation">
-            <summary>
-            Gets or sets a <see cref="T:System.Boolean"/> value that specifies whether the certificate revocation list
-            is checked during authentication.
             </summary>
         </member>
         <member name="P:WatsonTcp.WatsonTcpServerSslConfiguration.ClientCertificateRequired">

--- a/WatsonTcp/WatsonTcp.xml
+++ b/WatsonTcp/WatsonTcp.xml
@@ -571,6 +571,11 @@
             Watson TCP keepalive settings.
             </summary>
         </member>
+        <member name="P:WatsonTcp.WatsonTcpClient.SslConfiguration">
+            <summary>
+            Watson TCP client SSL configuration.
+            </summary>
+        </member>
         <member name="P:WatsonTcp.WatsonTcpClient.Connected">
             <summary>
             Indicates whether or not the client is connected to the server.
@@ -857,6 +862,48 @@
             Instantiate the object.
             </summary>
         </member>
+        <member name="T:WatsonTcp.WatsonTcpClientSslConfiguration">
+            <summary>
+            Stores the parameters for the <see cref="T:System.Net.Security.SslStream"/> used by clients.
+            </summary>
+        </member>
+        <member name="P:WatsonTcp.WatsonTcpClientSslConfiguration.CheckCertificateRevocation">
+            <summary>
+            Gets or sets a <see cref="T:System.Boolean"/> value that specifies whether the certificate revocation list
+            is checked during authentication.
+            </summary>
+        </member>
+        <member name="P:WatsonTcp.WatsonTcpClientSslConfiguration.ClientCertificateSelectionCallback">
+            <summary>
+            Gets or sets a <see cref="T:System.Net.Security.LocalCertificateSelectionCallback"/> delegate responsible for
+            selecting the certificate used for authentication.
+            </summary>
+            <remarks>The default delegate returns the first certificate in the collection</remarks>
+        </member>
+        <member name="P:WatsonTcp.WatsonTcpClientSslConfiguration.ServerCertificateValidationCallback">
+            <summary>
+            Gets or sets a <see cref="T:System.Net.Security.RemoteCertificateValidationCallback"/> delegate responsible
+            for validating the certificate supplied by the remote party.
+            </summary>
+            <remarks>
+            The default delegate returns true for all certificates
+            </remarks>
+        </member>
+        <member name="M:WatsonTcp.WatsonTcpClientSslConfiguration.#ctor">
+            <summary>
+            Initializes a new instance of <see cref="T:WatsonTcp.WatsonTcpClientSslConfiguration"/>.
+            </summary>
+        </member>
+        <member name="M:WatsonTcp.WatsonTcpClientSslConfiguration.#ctor(WatsonTcp.WatsonTcpClientSslConfiguration)">
+            <summary>
+            Initializes a new instance of <see cref="T:WatsonTcp.WatsonTcpClientSslConfiguration"/>
+            that stores the parameters copied from another configuration.
+            </summary>
+            <param name="configuration">
+            A <see cref="T:WatsonTcp.WatsonTcpClientSslConfiguration"/> from which to copy.
+            </param>
+            <exception cref="T:System.ArgumentNullException" />
+        </member>
         <member name="T:WatsonTcp.WatsonTcpKeepaliveSettings">
             <summary>
             Watson TCP keepalive settings.
@@ -924,6 +971,11 @@
         <member name="P:WatsonTcp.WatsonTcpServer.Keepalive">
             <summary>
             Watson TCP keepalive settings.
+            </summary>
+        </member>
+        <member name="P:WatsonTcp.WatsonTcpServer.SslConfiguration">
+            <summary>
+            Watson TCP server SSL configuration.
             </summary>
         </member>
         <member name="P:WatsonTcp.WatsonTcpServer.Connections">
@@ -1260,6 +1312,47 @@
             <summary>
             Instantiate the object.
             </summary>
+        </member>
+        <member name="T:WatsonTcp.WatsonTcpServerSslConfiguration">
+            <summary>
+            Stores the parameters for the <see cref="T:System.Net.Security.SslStream"/> used by servers.
+            </summary>
+        </member>
+        <member name="P:WatsonTcp.WatsonTcpServerSslConfiguration.CheckCertificateRevocation">
+            <summary>
+            Gets or sets a <see cref="T:System.Boolean"/> value that specifies whether the certificate revocation list
+            is checked during authentication.
+            </summary>
+        </member>
+        <member name="P:WatsonTcp.WatsonTcpServerSslConfiguration.ClientCertificateRequired">
+            <summary>
+            Gets or sets a value indicating whether the client is asked for
+            a certificate for authentication.
+            </summary>
+        </member>
+        <member name="P:WatsonTcp.WatsonTcpServerSslConfiguration.ClientCertificateValidationCallback">
+            <summary>
+            Gets or sets a <see cref="T:System.Net.Security.RemoteCertificateValidationCallback"/> delegate responsible
+            for validating the certificate supplied by the remote party.
+            </summary>
+            <remarks>
+            The default delegate returns true for all certificates
+            </remarks>
+        </member>
+        <member name="M:WatsonTcp.WatsonTcpServerSslConfiguration.#ctor">
+            <summary>
+            Initializes a new instance of <see cref="T:WatsonTcp.WatsonTcpServerSslConfiguration"/>.
+            </summary>
+        </member>
+        <member name="M:WatsonTcp.WatsonTcpServerSslConfiguration.#ctor(WatsonTcp.WatsonTcpServerSslConfiguration)">
+            <summary>
+            Initializes a new instance of the <see cref="T:WatsonTcp.WatsonTcpServerSslConfiguration"/>
+            class that stores the parameters copied from another configuration.
+            </summary>
+            <param name="configuration">
+            A <see cref="T:WatsonTcp.WatsonTcpServerSslConfiguration"/> from which to copy.
+            </param>
+            <exception cref="T:System.ArgumentNullException"/>
         </member>
         <member name="T:WatsonTcp.WatsonTcpStatistics">
             <summary>

--- a/WatsonTcp/WatsonTcpClient.cs
+++ b/WatsonTcp/WatsonTcpClient.cs
@@ -371,7 +371,7 @@ namespace WatsonTcp
                     else
                         _SslStream = new SslStream(_Client.GetStream(), false);
 
-                    _SslStream.AuthenticateAsClient(_ServerIp, _SslCertificateCollection, _TlsVersion.ToSslProtocols(), _SslConfiguration.CheckCertificateRevocation);
+                    _SslStream.AuthenticateAsClient(_ServerIp, _SslCertificateCollection, _TlsVersion.ToSslProtocols(), !_Settings.AcceptInvalidCertificates);
 
                     if (!_SslStream.IsEncrypted)
                     {

--- a/WatsonTcp/WatsonTcpClientSslConfiguration.cs
+++ b/WatsonTcp/WatsonTcpClientSslConfiguration.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace WatsonTcp
+{
+    /// <summary>
+    /// Stores the parameters for the <see cref="SslStream"/> used by clients.
+    /// </summary>
+    public class WatsonTcpClientSslConfiguration
+    {
+        #region Public-Members
+
+        /// <summary>
+        /// Gets or sets a <see cref="bool"/> value that specifies whether the certificate revocation list
+        /// is checked during authentication.
+        /// </summary>
+        public bool CheckCertificateRevocation
+        {
+            get
+            {
+                return _CheckCertRevocation;
+            }
+
+            set
+            {
+                _CheckCertRevocation = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a <see cref="LocalCertificateSelectionCallback"/> delegate responsible for
+        /// selecting the certificate used for authentication.
+        /// </summary>
+        /// <remarks>The default delegate returns the first certificate in the collection</remarks>
+        public LocalCertificateSelectionCallback ClientCertificateSelectionCallback
+        {
+            get
+            {
+                if (_ClientCertSelectionCallback == null)
+                    _ClientCertSelectionCallback = DefaultSelectClientCertificate;
+
+                return _ClientCertSelectionCallback;
+            }
+
+            set
+            {
+                _ClientCertSelectionCallback = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a <see cref="RemoteCertificateValidationCallback"/> delegate responsible
+        /// for validating the certificate supplied by the remote party.
+        /// </summary>
+        /// <remarks>
+        /// The default delegate returns true for all certificates
+        /// </remarks>
+        public RemoteCertificateValidationCallback ServerCertificateValidationCallback
+        {
+            get
+            {
+                if (_ServerCertValidationCallback == null)
+                    _ServerCertValidationCallback = DefaultValidateServerCertificate;
+
+                return _ServerCertValidationCallback;
+            }
+
+            set
+            {
+                _ServerCertValidationCallback = value;
+            }
+        }
+        #endregion
+
+        #region Private-Members
+
+        private bool _CheckCertRevocation;
+        private LocalCertificateSelectionCallback _ClientCertSelectionCallback;
+        private RemoteCertificateValidationCallback _ServerCertValidationCallback;
+
+        #endregion
+
+        #region Constructors-and-Factories
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="WatsonTcpClientSslConfiguration"/>.
+        /// </summary>
+        public WatsonTcpClientSslConfiguration()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="WatsonTcpClientSslConfiguration"/>
+        /// that stores the parameters copied from another configuration.
+        /// </summary>
+        /// <param name="configuration">
+        /// A <see cref="WatsonTcpClientSslConfiguration"/> from which to copy.
+        /// </param>
+        /// <exception cref="ArgumentNullException" />
+        public WatsonTcpClientSslConfiguration(WatsonTcpClientSslConfiguration configuration)
+        {
+            if (configuration == null)
+                throw new ArgumentNullException("Can not copy from null client SSL configuration");
+
+            _CheckCertRevocation = configuration._CheckCertRevocation;
+            _ClientCertSelectionCallback = configuration._ClientCertSelectionCallback;
+            _ServerCertValidationCallback = configuration._ServerCertValidationCallback;
+        }
+
+        #endregion
+
+        #region Public-Methods
+
+        #endregion
+
+        #region Private-Methods
+
+        private static X509Certificate DefaultSelectClientCertificate(
+          object sender,
+          string targetHost,
+          X509CertificateCollection clientCertificates,
+          X509Certificate serverCertificate,
+          string[] acceptableIssuers
+        )
+        {
+            return clientCertificates[0];
+        }
+
+        private static bool DefaultValidateServerCertificate(
+          object sender,
+          X509Certificate certificate,
+          X509Chain chain,
+          SslPolicyErrors sslPolicyErrors
+        )
+        {
+            return true;
+        }
+
+        #endregion
+    }
+}

--- a/WatsonTcp/WatsonTcpClientSslConfiguration.cs
+++ b/WatsonTcp/WatsonTcpClientSslConfiguration.cs
@@ -12,23 +12,6 @@ namespace WatsonTcp
         #region Public-Members
 
         /// <summary>
-        /// Gets or sets a <see cref="bool"/> value that specifies whether the certificate revocation list
-        /// is checked during authentication.
-        /// </summary>
-        public bool CheckCertificateRevocation
-        {
-            get
-            {
-                return _CheckCertRevocation;
-            }
-
-            set
-            {
-                _CheckCertRevocation = value;
-            }
-        }
-
-        /// <summary>
         /// Gets or sets a <see cref="LocalCertificateSelectionCallback"/> delegate responsible for
         /// selecting the certificate used for authentication.
         /// </summary>
@@ -75,7 +58,6 @@ namespace WatsonTcp
 
         #region Private-Members
 
-        private bool _CheckCertRevocation;
         private LocalCertificateSelectionCallback _ClientCertSelectionCallback;
         private RemoteCertificateValidationCallback _ServerCertValidationCallback;
 
@@ -103,7 +85,6 @@ namespace WatsonTcp
             if (configuration == null)
                 throw new ArgumentNullException("Can not copy from null client SSL configuration");
 
-            _CheckCertRevocation = configuration._CheckCertRevocation;
             _ClientCertSelectionCallback = configuration._ClientCertSelectionCallback;
             _ServerCertValidationCallback = configuration._ServerCertValidationCallback;
         }

--- a/WatsonTcp/WatsonTcpServer.cs
+++ b/WatsonTcp/WatsonTcpServer.cs
@@ -845,7 +845,7 @@ namespace WatsonTcp
         {
             try
             { 
-                await client.SslStream.AuthenticateAsServerAsync(_SslCertificate, _SslConfiguration.ClientCertificateRequired, _TlsVersion.ToSslProtocols(), _SslConfiguration.CheckCertificateRevocation).ConfigureAwait(false);
+                await client.SslStream.AuthenticateAsServerAsync(_SslCertificate, _SslConfiguration.ClientCertificateRequired, _TlsVersion.ToSslProtocols(), !_Settings.AcceptInvalidCertificates).ConfigureAwait(false);
 
                 if (!client.SslStream.IsEncrypted)
                 {

--- a/WatsonTcp/WatsonTcpServerSslConfiguration.cs
+++ b/WatsonTcp/WatsonTcpServerSslConfiguration.cs
@@ -12,23 +12,6 @@ namespace WatsonTcp
         #region Public-Members
 
         /// <summary>
-        /// Gets or sets a <see cref="bool"/> value that specifies whether the certificate revocation list
-        /// is checked during authentication.
-        /// </summary>
-        public bool CheckCertificateRevocation
-        {
-            get
-            {
-                return _CheckCertRevocation;
-            }
-
-            set
-            {
-                _CheckCertRevocation = value;
-            }
-        }
-
-        /// <summary>
         /// Gets or sets a value indicating whether the client is asked for
         /// a certificate for authentication.
         /// </summary>
@@ -72,8 +55,7 @@ namespace WatsonTcp
 
         #region Private-Members
 
-        private bool _CheckCertRevocation;
-        private bool _ClientCertRequired;
+        private bool _ClientCertRequired = true;
         private RemoteCertificateValidationCallback _ClientCertValidationCallback;
 
         #endregion
@@ -100,7 +82,6 @@ namespace WatsonTcp
             if (configuration == null)
                 throw new ArgumentNullException("Can not copy from null server SSL configuration");
 
-            _CheckCertRevocation = configuration._CheckCertRevocation;
             _ClientCertRequired = configuration._ClientCertRequired;
             _ClientCertValidationCallback = configuration._ClientCertValidationCallback;
         }

--- a/WatsonTcp/WatsonTcpServerSslConfiguration.cs
+++ b/WatsonTcp/WatsonTcpServerSslConfiguration.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace WatsonTcp
+{
+    /// <summary>
+    /// Stores the parameters for the <see cref="SslStream"/> used by servers.
+    /// </summary>
+    public class WatsonTcpServerSslConfiguration
+    {
+        #region Public-Members
+
+        /// <summary>
+        /// Gets or sets a <see cref="bool"/> value that specifies whether the certificate revocation list
+        /// is checked during authentication.
+        /// </summary>
+        public bool CheckCertificateRevocation
+        {
+            get
+            {
+                return _CheckCertRevocation;
+            }
+
+            set
+            {
+                _CheckCertRevocation = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the client is asked for
+        /// a certificate for authentication.
+        /// </summary>
+        public bool ClientCertificateRequired
+        {
+            get
+            {
+                return _ClientCertRequired;
+            }
+
+            set
+            {
+                _ClientCertRequired = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a <see cref="RemoteCertificateValidationCallback"/> delegate responsible
+        /// for validating the certificate supplied by the remote party.
+        /// </summary>
+        /// <remarks>
+        /// The default delegate returns true for all certificates
+        /// </remarks>
+        public RemoteCertificateValidationCallback ClientCertificateValidationCallback
+        {
+            get
+            {
+                if (_ClientCertValidationCallback == null)
+                    _ClientCertValidationCallback = DefaultValidateClientCertificate;
+
+                return _ClientCertValidationCallback;
+            }
+
+            set
+            {
+                _ClientCertValidationCallback = value;
+            }
+        }
+
+        #endregion
+
+        #region Private-Members
+
+        private bool _CheckCertRevocation;
+        private bool _ClientCertRequired;
+        private RemoteCertificateValidationCallback _ClientCertValidationCallback;
+
+        #endregion
+
+        #region Constructors-and-Factories
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="WatsonTcpServerSslConfiguration"/>.
+        /// </summary>
+        public WatsonTcpServerSslConfiguration()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WatsonTcpServerSslConfiguration"/>
+        /// class that stores the parameters copied from another configuration.
+        /// </summary>
+        /// <param name="configuration">
+        /// A <see cref="WatsonTcpServerSslConfiguration"/> from which to copy.
+        /// </param>
+        /// <exception cref="ArgumentNullException"/>
+        public WatsonTcpServerSslConfiguration(WatsonTcpServerSslConfiguration configuration)
+        {
+            if (configuration == null)
+                throw new ArgumentNullException("Can not copy from null server SSL configuration");
+
+            _CheckCertRevocation = configuration._CheckCertRevocation;
+            _ClientCertRequired = configuration._ClientCertRequired;
+            _ClientCertValidationCallback = configuration._ClientCertValidationCallback;
+        }
+
+        #endregion
+
+        #region Public-Methods
+
+        #endregion
+
+        #region Private-Methods
+
+        private static bool DefaultValidateClientCertificate(
+          object sender,
+          X509Certificate certificate,
+          X509Chain chain,
+          SslPolicyErrors sslPolicyErrors
+        )
+        {
+            return true;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Hello! In our project we have a need to do some additional certificate validation on the client side and server side. This pull request is to provide additional options for configuring the underlying SslStream when accepting invalid certificates. The changes are done with backwards compatibility in mind: if you don't modify SslConfiguration then it works the same way it currently does.