### PR TITLE
Disable client certificate selection in default selection callback when no certificates are available

### DIFF
--- a/WatsonTcp/WatsonTcpClientSslConfiguration.cs
+++ b/WatsonTcp/WatsonTcpClientSslConfiguration.cs
@@ -105,11 +105,12 @@ namespace WatsonTcp
           string[] acceptableIssuers
         )
         {
-            if (clientCertificates.Count > 0)
+            if (clientCertificates == null || clientCertificates.Count == 0)
             {
-                return clientCertificates[0];
+                return null;
             }
-            return null;
+
+            return clientCertificates[0];
         }
 
         private static bool DefaultValidateServerCertificate(


### PR DESCRIPTION
Fixes #158 