### PR TITLE
Reuse byte array to save 65536 bytes on every msg sent for Send function

### DIFF
--- a/WatsonTcp/WatsonTcpClient.cs
+++ b/WatsonTcp/WatsonTcpClient.cs
@@ -1161,6 +1161,12 @@ namespace WatsonTcp
              
             long bytesRemaining = contentLength;
             int bytesRead = 0;
+
+            if (_Settings.StreamBufferSize > _BufferPool.Length)
+            {
+                _BufferPool = new byte[_Settings.StreamBufferSize];
+            }
+
             byte[] buffer = _BufferPool;
               
             while (bytesRemaining > 0)

--- a/WatsonTcp/WatsonTcpClient.cs
+++ b/WatsonTcp/WatsonTcpClient.cs
@@ -160,7 +160,7 @@ namespace WatsonTcp
 
         private readonly object _SyncResponseLock = new object();
         private Dictionary<string, SyncResponse> _SyncResponses = new Dictionary<string, SyncResponse>(); 
-
+        private byte[] _BufferPool = null;
         #endregion
 
         #region Constructors-and-Factories
@@ -182,6 +182,8 @@ namespace WatsonTcp
             _ServerPort = serverPort;
 
             SerializationHelper.InstantiateConverter(); // Unity fix
+
+            _BufferPool = new byte[_Settings.StreamBufferSize];
         }
 
         /// <summary>
@@ -229,6 +231,8 @@ namespace WatsonTcp
             }
 
             SerializationHelper.InstantiateConverter(); // Unity fix
+
+            _BufferPool = new byte[_Settings.StreamBufferSize];
         }
 
         /// <summary>
@@ -260,6 +264,8 @@ namespace WatsonTcp
             };
 
             SerializationHelper.InstantiateConverter(); // Unity fix
+            
+            _BufferPool = new byte[_Settings.StreamBufferSize];
         }
 
         #endregion
@@ -1155,7 +1161,7 @@ namespace WatsonTcp
              
             long bytesRemaining = contentLength;
             int bytesRead = 0;
-            byte[] buffer = new byte[_Settings.StreamBufferSize];
+            byte[] buffer = _BufferPool;
               
             while (bytesRemaining > 0)
             { 

--- a/WatsonTcp/WatsonTcpServer.cs
+++ b/WatsonTcp/WatsonTcpServer.cs
@@ -1418,6 +1418,12 @@ namespace WatsonTcp
 
             long bytesRemaining = contentLength;
             int bytesRead = 0;
+
+            if (_Settings.StreamBufferSize > _BufferPool.Length)
+            {
+                _BufferPool = new byte[_Settings.StreamBufferSize];
+            }
+
             byte[] buffer = _BufferPool;
              
             while (bytesRemaining > 0)

--- a/WatsonTcp/WatsonTcpServer.cs
+++ b/WatsonTcp/WatsonTcpServer.cs
@@ -174,7 +174,8 @@ namespace WatsonTcp
 
         private readonly object _SyncResponseLock = new object();
         private Dictionary<string, SyncResponse> _SyncResponses = new Dictionary<string, SyncResponse>();
-         
+        private byte[] _BufferPool = null;
+
         #endregion
 
         #region Constructors-and-Factories
@@ -214,6 +215,8 @@ namespace WatsonTcp
             _ListenerPort = listenerPort;
 
             SerializationHelper.InstantiateConverter(); // Unity fix
+
+            _BufferPool = new byte[_Settings.StreamBufferSize];
         }
 
         /// <summary>
@@ -269,6 +272,8 @@ namespace WatsonTcp
             _ListenerPort = listenerPort;
 
             SerializationHelper.InstantiateConverter(); // Unity fix
+
+            _BufferPool = new byte[_Settings.StreamBufferSize];
         }
 
         /// <summary>
@@ -314,6 +319,8 @@ namespace WatsonTcp
             _ListenerPort = listenerPort;
 
             SerializationHelper.InstantiateConverter(); // Unity fix
+
+            _BufferPool = new byte[_Settings.StreamBufferSize];
         }
 
         #endregion
@@ -1411,7 +1418,7 @@ namespace WatsonTcp
 
             long bytesRemaining = contentLength;
             int bytesRead = 0;
-            byte[] buffer = new byte[_Settings.StreamBufferSize];
+            byte[] buffer = _BufferPool;
              
             while (bytesRemaining > 0)
             {


### PR DESCRIPTION
usecase:
for games that needs to send msgs at fast pace it is causing too much GC