### PR TITLE
Future proof keepalive settings

### DIFF
--- a/src/WatsonTcp/WatsonTcpClient.cs
+++ b/src/WatsonTcp/WatsonTcpClient.cs
@@ -703,7 +703,7 @@ namespace WatsonTcp
         {
             try
             {
-#if NETCOREAPP || NET5_0
+#if NETCOREAPP || NET5_0_OR_GREATER
 
                 _Client.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
                 _Client.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, _Keepalive.TcpKeepAliveTime);

--- a/src/WatsonTcp/WatsonTcpServer.cs
+++ b/src/WatsonTcp/WatsonTcpServer.cs
@@ -708,7 +708,7 @@ namespace WatsonTcp
         {
             try
             {
-#if NETCOREAPP || NET5_0
+#if NETCOREAPP || NET5_0_OR_GREATER
 
                 client.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
                 client.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, _Keepalive.TcpKeepAliveTime);


### PR DESCRIPTION
I noticed the keepalive settings wouldn't take effect if the library user targets NET6+. As per https://docs.microsoft.com/en-us/dotnet/standard/frameworks I've changed `NET5_0` to `NET5_0_OR_GREATER`. This should future proof any NETx targets.