### PR TITLE
Dispose SSL Certificate

### DIFF
--- a/src/WatsonTcp/WatsonTcpClient.cs
+++ b/src/WatsonTcp/WatsonTcpClient.cs
@@ -663,6 +663,11 @@ namespace WatsonTcp
 
                 if (Connected) Disconnect();
 
+                if (_SslCertificate != null)
+                {
+                    _SslCertificate.Dispose();
+                }
+
                 if (_WriteLock != null)
                 {
                     _WriteLock.Dispose();

--- a/src/WatsonTcp/WatsonTcpServer.cs
+++ b/src/WatsonTcp/WatsonTcpServer.cs
@@ -674,6 +674,11 @@ namespace WatsonTcp
                     }
                 }
 
+                if (_SslCertificate != null)
+                {
+                    _SslCertificate.Dispose();
+                }
+
                 _Settings = null;
                 _Events = null;
                 _Callbacks = null;


### PR DESCRIPTION
Microsoft's CryptoAPI stores private keys in a directory unless the Certificate Store is used. It is necessary to Dispose the X509Certificate2 object to remove this file, otherwise it is never deleted.