### PR TITLE
Status inside WatsonMessage is now a property instead of a field

### DIFF
--- a/src/WatsonTcp/WatsonMessage.cs
+++ b/src/WatsonTcp/WatsonMessage.cs
@@ -59,7 +59,7 @@ namespace WatsonTcp
         /// Status of the message.   
         /// </summary>
         [JsonPropertyName("status")]
-        public MessageStatus Status = MessageStatus.Normal;
+        public MessageStatus Status { get; set; } = MessageStatus.Normal;
 
         /// <summary>
         /// Metadata dictionary; contains user-supplied metadata.

--- a/src/WatsonTcp/WatsonTcp.xml
+++ b/src/WatsonTcp/WatsonTcp.xml
@@ -532,7 +532,7 @@
             Preshared key for connection authentication.
             </summary>
         </member>
-        <member name="F:WatsonTcp.WatsonMessage.Status">
+        <member name="P:WatsonTcp.WatsonMessage.Status">
             <summary>
             Status of the message.   
             </summary>


### PR DESCRIPTION
Since Status was a public field and not a property it was not serialized by System.Text.Json. This caused the headers to be written without the status field and consequently the MessageReceived event to be called each time a header was received.

Probably this issue didn't appear before because Newtonsoft.json handles fields like properties. Moving from Newtonsoft.Json to System.Text.Json made this bug evident.

Same story here [https://github.com/jchristn/WatsonTcp/issues/226#issue-1469446251](url) .